### PR TITLE
DA GNM AWS GR URL Fix for Restore Status Page

### DIFF
--- a/gnmawsgr/templates/gnmawsgr/restore_status.html
+++ b/gnmawsgr/templates/gnmawsgr/restore_status.html
@@ -14,7 +14,7 @@
 
     $( "#opener{{ entry.item_id }}" ).click(function() {
       $( "#dialog{{ entry.item_id }}" ).dialog( "open" );
-      $( "#dialog{{ entry.item_id }}" ).load( "/gnmawsgr/re/?id={{ entry.item_id }}&path={{ entry.filepath_original }}" );
+      $( "#dialog{{ entry.item_id }}" ).load( "/gnmawsgr/re/?id={{ entry.item_id }}" );
     });
   });
   {% endfor %}


### PR DESCRIPTION
Removes path from URL to stop non-ASCII characters breaking loading of the HTML page. @fredex42 