### PR TITLE
DA Speed Up GNM AWS GR

### DIFF
--- a/gnmawsgr/tasks.py
+++ b/gnmawsgr/tasks.py
@@ -213,7 +213,7 @@ def do_glacier_restore(request_id,itemid,path):
 
     temp_path = "/tmp"
     restore_time = 2 #in days
-    restore_sleep_delay = 14400 #wait this number of seconds for something to restore
+    restore_sleep_delay = 1800 #wait this number of seconds for something to restore
     restore_short_delay = 600
 
     if hasattr(settings,'GLACIER_TEMP_PATH'):


### PR DESCRIPTION
Changing first restore delay to thirty minutes to see if GNM AWS GR restores files faster. This has not been tested.

@fredex42 