### PR TITLE
DA GNM PagerDuty Fix Two

### DIFF
--- a/gnmpagerduty/tasks.py
+++ b/gnmpagerduty/tasks.py
@@ -173,20 +173,6 @@ def check_storage(celery_app=None):
 
     log.info("check_storage run by Celery.")
 
-    if celery_app is None:
-        app = Celery()
-    else:
-        app=celery_app
-
-    i = app.control.inspect()
-
-    running = str(i.active())
-
-    rnumber = running.count("check_storage")
-
-    if rnumber > 1:
-        raise RuntimeError("Task aborted to avoid duplication")
-
     storage_data = VSStoragePathMap(url=settings.VIDISPINE_URL,port=settings.VIDISPINE_PORT,
                                     user=settings.VIDISPINE_USERNAME,passwd=settings.VIDISPINE_PASSWORD,
                                     run_as=settings.VIDISPINE_USERNAME)

--- a/gnmpagerduty/tests/test_tasks.py
+++ b/gnmpagerduty/tests/test_tasks.py
@@ -146,19 +146,6 @@ class TestTasks(unittest.TestCase):
         def __dict__(self):
             return self.obj
 
-    def test_check_storages_dedupe(self):
-        """
-        test that check_storages bails out if another running instance is detected
-        :return:
-        """
-        mockceleryapp = self.MockCeleryApp(2)
-
-        with patch('gnmvidispine.vs_storage.VSStoragePathMap', return_value={}) as mock_path_map:
-            from gnmpagerduty.tasks import check_storage
-
-            self.assertRaises(RuntimeError, check_storage, celery_app=mockceleryapp)
-            mock_path_map.assert_not_called()
-
     def test_check_storages_above(self):
         """
         tests the check_storages function when the storage is above the limit, i.e. fine


### PR DESCRIPTION
A simple fix that removes some code (and the test for it) that was failing to work on the live system due to, I suspect, inadequate Celery capacity. This was not an issue on the test systems.

@fredex42 