### PR TITLE
Bugfixes for gnmatomresponder

### DIFF
--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -197,7 +197,10 @@ class MasterImportResponder(KinesisResponder, S3Mixin):
 
         download_url = "file://" + urllib.quote(downloaded_path)
 
-        logger.info("{2}: Download URL for {0} is {1}".format(content['atomId'], download_url, content.get('title','(unknown title)')))
+        try:
+            logger.info(u"{2}: Download URL for {0} is {1}".format(content['atomId'], download_url, content.get('title','(unknown title)').decode("UTF-8","backslashescape")))
+        except UnicodeEncodeError:
+            pass
 
         job_result = master_item.import_to_shape(uri=download_url,
                                                  essence=True,

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -96,7 +96,7 @@ class MasterImportResponder(KinesisResponder, S3Mixin):
         userid = MasterImportResponder.get_userid_for_email(user)
         if userid is not None:
             metadata.update({
-                'owner': userid
+                const.GNM_MASTERS_GENERIC_OWNER: userid
             })
 
         item.createPlaceholder(metadata, group='Asset')


### PR DESCRIPTION
- unicode errors in debugging output
- duplication of filenames
- 'owner' field not being valid