### PR TITLE
Fix for 500 error when exporting report from syndication dash

### DIFF
--- a/portal/plugins/gnmatomresponder/tasks.py
+++ b/portal/plugins/gnmatomresponder/tasks.py
@@ -21,7 +21,7 @@ def cleanup_old_importjobs():
     try:
         qs = ImportJob.objects\
             .filter(Q(status='FINISHED') | Q(status='FINISHED_WARNING'))\
-            .filter(completed_at__gte=datetime.now()-timedelta(days=30))
+            .filter(completed_at__lte=datetime.now()-timedelta(days=30))
 
         logger.info("Cleaning out {0} import jobs".format(qs.count()))
         qs.delete()

--- a/portal/plugins/gnmatomresponder/tests/test_tasks.py
+++ b/portal/plugins/gnmatomresponder/tests/test_tasks.py
@@ -22,10 +22,11 @@ class TestTasks(django.test.TestCase):
         """
         from portal.plugins.gnmatomresponder.models import ImportJob
         from portal.plugins.gnmatomresponder.tasks import cleanup_old_importjobs
-        #FIXME: still need to patch datetime.now() to always return the same value
+        #FIXME: should patch datetime.now() to always return the same value, for time being rely on fixture values being much
+        #older than 60 days.
         self.assertEqual(ImportJob.objects.all().count(), 5)
         cleanup_old_importjobs()
-        self.assertEqual(ImportJob.objects.all().count(), 4)
+        self.assertEqual(ImportJob.objects.all().count(), 3)
 
     def test_delete_from_s3(self):
         """

--- a/portal/plugins/gnmsyndication/views.py
+++ b/portal/plugins/gnmsyndication/views.py
@@ -1,14 +1,14 @@
 from django.http import HttpResponse
 from django.shortcuts import render
-import xml.etree.ElementTree as ET
 import datetime
 import dateutil
 import logging
 from django.conf import settings
 import re
 from models import platform
+import traceback
 
-logger = logging.getLogger("portal.plugins.gnmsyndication")
+logger = logging.getLogger(__name__)
 
 
 def date_fields():
@@ -595,10 +595,14 @@ def assets_by_day(request,date):
 
 
 def seconds_to_duration(nsec):
-    m, s = divmod(float(nsec), 60)
-    h, m = divmod(m, 60)
-    #print "%d:%02d:%02d" % (h, m, s)
-    return u"%02d:%02d:%02d" % (h,m,s)
+    try:
+        m, s = divmod(float(nsec), 60)
+        h, m = divmod(m, 60)
+        #print "%d:%02d:%02d" % (h, m, s)
+        return u"%02d:%02d:%02d" % (h,m,s)
+    except Exception as e:
+        logger.warning(traceback.format_exc())
+        return u"Unable to convert from '{0}'".format(nsec)
 
 
 def csv_report(request):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,7 +22,7 @@ python-dateutil==2.1
 python-digest==1.7
 python-ldap==2.4.10
 python-memcached==1.48
-psycopg2==2.5.1
+psycopg2==2.7.3.2
 oauth2client==1.2
 ordereddict==1.1
 orderedset==1.1.2


### PR DESCRIPTION
If the created field has no value it caused the export to bomb out on an exception.