### PR TITLE
Fix for apparently failing link transcodes

### DIFF
--- a/portal/plugins/gnmdownloadablelink/tasks.py
+++ b/portal/plugins/gnmdownloadablelink/tasks.py
@@ -133,6 +133,7 @@ def multipart_upload_vsfile_to_s3(file_ref,filename,mime_type):
             total_size+=uploaded.size
             n+=1
         except ChunkDoesNotExist:
+            logger.debug("Chunk does not exist, stopping")
             break
 
     #we should have completed the upload here
@@ -177,16 +178,20 @@ def upload_to_s3(shape_ref,filename):
     s3key = None
     n = 0
 
-    for file in shape_ref.files():
-        try:
-            n+=1
-            extension = get_vsfile_extension(file)
-            s3key = upload_vsfile_to_s3(file, "{0}.{1}".format(filename, extension),shape_ref.mime_type)
-            uploaded = True
+    for retry in range(1, int(getattr(settings,'DOWNLOADABLE_LINK_RETRY_LIMIT'), 15)):
+        logger.info("Upload of any shape for {0}, attempt {1}".format(shape_ref.name, retry))
+        for file in shape_ref.files():
+            try:
+                n+=1
+                extension = get_vsfile_extension(file)
+                s3key = upload_vsfile_to_s3(file, "{0}.{1}".format(filename, extension),shape_ref.mime_type)
+                uploaded = True
+                break
+            except NeedsRetry:
+                logger.warning("Upload of file {0} from shape {1} failed, trying next one".format(file.name, shape_ref.name))
+                pass
+        if uploaded:
             break
-        except NeedsRetry:
-            logger.warning("Upload of file {0} from shape {1} failed, trying next one".format(file.name, shape_ref.name))
-            pass
 
     if n==0:
         #this is caught at the caller, and causes the task to schedule a retry

--- a/portal/plugins/gnmdownloadablelink/tasks.py
+++ b/portal/plugins/gnmdownloadablelink/tasks.py
@@ -178,7 +178,7 @@ def upload_to_s3(shape_ref,filename):
     s3key = None
     n = 0
 
-    for retry in range(1, int(getattr(settings,'DOWNLOADABLE_LINK_RETRY_LIMIT'), 15)):
+    for retry in range(1, int(getattr(settings,'DOWNLOADABLE_LINK_RETRY_LIMIT', 15))):
         logger.info("Upload of any shape for {0}, attempt {1}".format(shape_ref.name, retry))
         for file in shape_ref.files():
             try:

--- a/portal/plugins/gnmdownloadablelink/tasks.py
+++ b/portal/plugins/gnmdownloadablelink/tasks.py
@@ -192,10 +192,9 @@ def upload_to_s3(shape_ref,filename):
                 pass
         if uploaded:
             break
-
-    if n==0:
-        #this is caught at the caller, and causes the task to schedule a retry
-        raise NeedsRetry("Shape {0} does not yet have any files.".format(shape_ref.name))
+        if n==0:
+            #this is caught at the caller, and causes the task to schedule a retry
+            raise NeedsRetry("Shape {0} does not yet have any files.".format(shape_ref.name))
 
     if not uploaded:
         logger.error("No files uploaded")


### PR DESCRIPTION
Fix for the issue where link creation that requires transcoding can fail at upload, especially if another link is already existing.

This adds some more retry conditions, so if there are no files (yet) existing on the shape, the upload will get retried after a configurable delay.