### PR TITLE
Handle media tool not yet received media

### DIFF
--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -140,8 +140,8 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
                 try:
                     request_atom_resend(content['atomId'], settings.ATOM_TOOL_HOST, settings.ATOM_TOOL_SECRET)
                 except HttpError as e:
-                    if e.code==404:
-                        if attempt>=10:
+                    if e.code == 404:
+                        if attempt >= 10:
                             logger.error("{0}: still nothing after 10 attempts. Giving up.".format(content['atomId']))
                             raise
                         logger.warning("{0}: Media atom tool responded with a 404 on attempt {1}: {2}. Retrying in 60s.".format(content['atomId'], attempt, e.content))

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -95,7 +95,7 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
             created = True
         return master_item, created
 
-    def process(self,record, approx_arrival):
+    def process(self,record, approx_arrival, attempt=0):
         """
         Process a message from the kinesis stream.  Each record is a JSON document which contains keys for atomId, s3Key,
         projectId.  This will find an item with the given atom ID or create a new one, get a signed download URL from
@@ -104,9 +104,11 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
         when the job terminates.
         :param record: JSON document in the form of a string
         :param approx_arrival:
+        :param attempt: optional integer showing how many times this has been retried
         :return:
         """
-        from media_atom import request_atom_resend
+        from media_atom import request_atom_resend, HttpError
+        from tasks import timed_request_resend
         content = json.loads(record)
 
         logger.info(content)
@@ -128,15 +130,6 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
             logger.info("PAC form data message complete")
         elif content['type'] == const.MESSAGE_TYPE_PROJECT_ASSIGNED:
             logger.info("Got project (re-)assignment message: {0}".format(content))
-            # project_collection = self.get_project_collection(content)
-            # if 'title' in content:
-            #     atom_title = content['title']
-            # else:
-            #     atom_title = None
-            # if 'user' in content:
-            #     atom_user = content['user']
-            # else:
-            #     atom_user = None
 
             master_item = self.get_item_for_atomid(content['atomId'])
             if master_item is not None:
@@ -144,7 +137,20 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
                 self.assign_atom_to_project(content['atomId'], content['commissionId'], content['projectId'], master_item)
             else:
                 logger.warning("No master item exists for atom {0}.  Requesting a re-send from media atom tool".format(content['atomId']))
-                request_atom_resend(content['atomId'], settings.ATOM_TOOL_HOST, settings.ATOM_TOOL_SECRET)
+                try:
+                    request_atom_resend(content['atomId'], settings.ATOM_TOOL_HOST, settings.ATOM_TOOL_SECRET)
+                except HttpError as e:
+                    if e.code==404:
+                        if attempt>=10:
+                            logger.error("{0}: still nothing after 10 attempts. Giving up.".format(content['atomId']))
+                            raise
+                        logger.warning("{0}: Media atom tool responded with a 404 on attempt {1}: {2}. Retrying in 60s.".format(content['atomId'], attempt, e.content))
+                        timed_request_resend.apply_async(args=(record, approx_arrival),
+                                                         kwargs={'attempt': attempt+1},
+                                                         countdown=60)
+                    else:
+                        logger.exception("{0}: Could not request resync".format(content['atomId']))
+
             logger.info("Project (re-)assignment complete")
         else:
             raise ValueError("Unrecognised message type: {0}".format(content['type']))

--- a/portal/plugins/gnmatomresponder/tests/test_master_importer.py
+++ b/portal/plugins/gnmatomresponder/tests/test_master_importer.py
@@ -288,3 +288,37 @@ class TestMasterImporter(django.test.TestCase):
             mock_collection.get.assert_called_once_with(const.PARENT_COLLECTION)
             mock_collection.addToCollection.assert_called_once_with(mock_item)
             m.set_project_fields_for_master.assert_called_once_with(mock_item, parent_project=mock_collection)
+
+    def test_process_outofsync_project_nomedia(self):
+        """
+        if a "project-assigned" message arrives and no media is available we should request a re-send from the atom tool.
+        if this returns a 404 we should call out to Celery to retry the _whole_ process (not just the download)
+        :return:
+        """
+        from portal.plugins.gnmatomresponder.master_importer import MasterImportResponder
+        import portal.plugins.gnmatomresponder.constants as const
+        from portal.plugins.gnmatomresponder.media_atom import HttpError
+        import json
+        from django.conf import settings
+        from gnmvidispine.vs_item import VSItem
+
+        fake_message = json.dumps({
+            "type": const.MESSAGE_TYPE_PROJECT_ASSIGNED,
+            "atomId": "603CBB6C-A32D-4BD6-8053-CDEA99DC5406"
+        })
+
+        fake_response = json.dumps({
+            "status": "notfound",
+            "detail": "it's gone"
+        })
+
+        with patch('portal.plugins.gnmatomresponder.master_importer.MasterImportResponder.refresh_access_credentials'):
+            with patch('portal.plugins.gnmatomresponder.media_atom.request_atom_resend', side_effect=HttpError("http:/test-uri", 404, fake_response, {}, {})) as mock_request_resend:
+                with patch('portal.plugins.gnmatomresponder.tasks.timed_request_resend') as mock_retry_task:
+                    m = MasterImportResponder("fake role", "fake session", "fake stream", "shard-00000")
+                    m.get_item_for_atomid = MagicMock(return_value=None)
+
+                    m.process(fake_message, 0)
+
+                    mock_request_resend.assert_called_once_with("603CBB6C-A32D-4BD6-8053-CDEA99DC5406", settings.ATOM_TOOL_HOST, settings.ATOM_TOOL_SECRET)
+                    mock_retry_task.apply_async.assert_called_once_with(args=('{"atomId": "603CBB6C-A32D-4BD6-8053-CDEA99DC5406", "type": "project-assigned"}', 0), countdown=60, kwargs={'attempt': 1})


### PR DESCRIPTION
handle the new behaviour of media atom tool; when requesting a re-send, it will return a 404 if there is no media present on the atom yet.  When we receive this, we will schedule a celery task to re-try processing the entire message in 60s; hopefully by this time the media will have arrived.