### PR TITLE
DA Atom Lock

### DIFF
--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -183,16 +183,19 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
 
         vs_item_id = master_item.get("itemId")
 
-        importjob = ImportJob.objects.get(item_id=vs_item_id)
-
-        if importjob.processing == True:
-            logger.info('Data for item {0} already being processed. Aborting.'.format(vs_item_id))
-            inform_sentry_exception({
-                "master_item": master_item,
-                "content": content.__dict__,
-                "parent": parent
-            })
-            return
+        try:
+            importjob = ImportJob.objects.get(item_id=vs_item_id)
+        except:
+            pass
+        else:
+            if importjob.processing == True:
+                logger.info('Data for item {0} already being processed. Aborting.'.format(vs_item_id))
+                inform_sentry_exception({
+                    "master_item": master_item,
+                    "content": content.__dict__,
+                    "parent": parent
+                })
+                return
 
         safe_title = content.get('title','(unknown title)').encode("UTF-8","backslashescape").decode("UTF-8")
 

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -188,8 +188,8 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
         if importjob.processing == True:
             logger.info('Data for item {0} already being processed. Aborting.'.format(vs_item_id))
             inform_sentry_exception({
-                "master_item": master_item
-                "content": content.__dict__
+                "master_item": master_item,
+                "content": content.__dict__,
                 "parent": parent
             })
             return

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -181,7 +181,7 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
         if not isinstance(master_item, VSItem) and not isinstance(master_item, MagicMock): raise TypeError #for intellij
         from portal.plugins.kinesisresponder.sentry import inform_sentry
 
-        vs_item_id = master_item.get("itemId")
+        vs_item_id = master_item.name
 
         try:
             importjob = ImportJob.objects.get(item_id=vs_item_id)

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -179,6 +179,20 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
         from pac_xml import PacXmlProcessor
         from mock import MagicMock
         if not isinstance(master_item, VSItem) and not isinstance(master_item, MagicMock): raise TypeError #for intellij
+        from portal.plugins.kinesisresponder.sentry import inform_sentry_exception
+
+        vs_item_id = master_item.get("itemId")
+
+        importjob = ImportJob.objects.get(item_id=vs_item_id)
+
+        if importjob.processing == True:
+            logger.info('Data for item {0} already being processed. Aborting.'.format(vs_item_id))
+            inform_sentry_exception({
+                "master_item": master_item
+                "content": content.__dict__
+                "parent": parent
+            })
+            return
 
         safe_title = content.get('title','(unknown title)').encode("UTF-8","backslashescape").decode("UTF-8")
 
@@ -200,7 +214,6 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
         except UnicodeDecodeError:
             pass
 
-        vs_item_id = master_item.get("itemId")
         job_result = master_item.import_to_shape(uri=download_url,
                                                  essence=True,
                                                  shape_tag=getattr(settings,"ATOM_RESPONDER_SHAPE_TAG","lowres"),
@@ -228,7 +241,8 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
                            user_email=content.get('user',"Unknown user"),
                            atom_id=content['atomId'],
                            atom_title=content.get('title', "Unknown title"),
-                           s3_path=content['s3Key'])
+                           s3_path=content['s3Key'],
+                           processing=True)
         previous_attempt = record.previous_attempt()
         if previous_attempt:
             record.retry_number = previous_attempt.retry_number+1

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -179,18 +179,18 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
         from pac_xml import PacXmlProcessor
         from mock import MagicMock
         if not isinstance(master_item, VSItem) and not isinstance(master_item, MagicMock): raise TypeError #for intellij
-        from portal.plugins.kinesisresponder.sentry import inform_sentry_exception
+        from portal.plugins.kinesisresponder.sentry import inform_sentry
 
         vs_item_id = master_item.get("itemId")
 
         try:
             importjob = ImportJob.objects.get(item_id=vs_item_id)
-        except:
+        except ImportJob.DoesNotExist:
             pass
         else:
             if importjob.processing == True:
                 logger.info('Data for item {0} already being processed. Aborting.'.format(vs_item_id))
-                inform_sentry_exception({
+                inform_sentry('Data for item {0} already being processed. Aborting.'.format(vs_item_id), {
                     "master_item": master_item,
                     "content": content.__dict__,
                     "parent": parent

--- a/portal/plugins/gnmatomresponder/migrations/0005_manual__add_field_processing.py
+++ b/portal/plugins/gnmatomresponder/migrations/0005_manual__add_field_processing.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'ImportJob.processing'
+        db.add_column('gnmatomresponder_importjob', 'processing',
+                      self.gf('django.db.models.fields.BooleanField')(default=False))
+
+    def backwards(self, orm):
+        # Deleting field 'ImportJob.processing'
+        db.delete_column('gnmatomresponder_importjob', 'processing')
+
+
+    models = {
+        'gnmatomresponder.importjob': {
+            'Meta': {'ordering': "['-started_at']", 'object_name': 'ImportJob'},
+            'atom_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'db_index': 'True'}),
+            'atom_title': ('django.db.models.fields.CharField', [], {'default': "'Unknown title'", 'max_length': '1024'}),
+            'completed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'db_index': 'True'}),
+            'job_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64', 'db_index': 'True'}),
+            'processing': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'retry_number': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            's3_path': ('django.db.models.fields.CharField', [], {'max_length': '2048', 'null': 'True'}),
+            'started_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'user_email': ('django.db.models.fields.CharField', [], {'default': "'Unknown user'", 'max_length': '1024', 'db_index': 'True'})
+        },
+        'gnmatomresponder.pacformxml': {
+            'Meta': {'object_name': 'PacFormXml'},
+            'atom_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64', 'db_index': 'True'}),
+            'celery_task_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'db_index': 'True'}),
+            'completed': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_error': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'pacdata_url': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'received': ('django.db.models.fields.DateTimeField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'UNPROCESSED'", 'max_length': '32', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['gnmatomresponder']

--- a/portal/plugins/gnmatomresponder/models.py
+++ b/portal/plugins/gnmatomresponder/models.py
@@ -26,6 +26,7 @@ class ImportJob(models.Model):
     completed_at = models.DateTimeField(null=True)
     s3_path = models.CharField(max_length=2048, null=True)
     retry_number = models.IntegerField(default=0)
+    processing = models.BooleanField(default=False)
 
     class Meta:
         ordering = ['-started_at']

--- a/portal/plugins/gnmatomresponder/notification.py
+++ b/portal/plugins/gnmatomresponder/notification.py
@@ -200,6 +200,7 @@ def process_notification(notification):
     importjob = ImportJob.objects.get(job_id=notification.jobId)
     importjob.status = notification.status
     importjob.processing = False
+    importjob.save()
 
     if importjob.is_failed():
         handle_failed_job(importjob)

--- a/portal/plugins/gnmatomresponder/notification.py
+++ b/portal/plugins/gnmatomresponder/notification.py
@@ -199,6 +199,7 @@ def process_notification(notification):
     from models import ImportJob
     importjob = ImportJob.objects.get(job_id=notification.jobId)
     importjob.status = notification.status
+    importjob.processing = False
 
     if importjob.is_failed():
         handle_failed_job(importjob)


### PR DESCRIPTION
Adds a new Boolean field called 'processing' which defaults to False for use as a lock on jobs for a certain Vidispine id.

When a job is passed to Vidispine the field is set to True. When the job comes back from Vidispine the field gets set to False.

If the field is found to be set to True on a model with a corresponding Vidispine id. before the job is sent to Vidispine the function will return.

@fredex42 