### PR TITLE
DA Stop Pointless Atom Jobs when an Old Job Has 'FINISHED' Status

### DIFF
--- a/portal/plugins/gnmatomresponder/fixtures/ImportJobs.yaml
+++ b/portal/plugins/gnmatomresponder/fixtures/ImportJobs.yaml
@@ -14,6 +14,7 @@
     status: STARTED
     started_at: 2017-09-14T13:21:02Z
     atom_id: AFF32555-2EBD-455D-BAAA-74EF8BEE2877
+    processing: False
 - model: gnmatomresponder.importjob
   pk: 2
   fields:
@@ -46,3 +47,5 @@
     status: FINISHED
     started_at: 2017-01-14T13:21:02Z
     completed_at: 2017-01-14T13:48:00Z
+    s3_path: uploads/06636fe2-10f1-418f-b4df-91f5353931ac-3/complete
+    processing: True

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -205,7 +205,7 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
         if not isinstance(master_item, VSItem) and not isinstance(master_item, MagicMock): raise TypeError #for intellij
         from portal.plugins.kinesisresponder.sentry import inform_sentry
 
-        vs_item_id = master_item.name
+        vs_item_id = master_item.get("itemId")
 
         old_finished_jobs = self.check_for_old_finished_jobs(vs_item_id)
 

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -177,23 +177,23 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
     def check_for_old_finished_jobs(self, vs_item_id):
         from models import ImportJob
 
-        jobs = ImportJob.objects.filter(item_id=vs_item_id).filter(status='FINISHED')
+        jobs = ImportJob.objects.filter(item_id=vs_item_id).filter(status='FINISHED').count()
 
-        return len(jobs) > 0
+        return jobs > 0
 
     def check_key(self, key, vs_item_id):
         from models import ImportJob
 
-        jobs = ImportJob.objects.filter(item_id=vs_item_id).filter(s3_path=key)
+        jobs = ImportJob.objects.filter(item_id=vs_item_id).filter(s3_path=key).count()
 
-        return len(jobs) > 0
+        return jobs > 0
 
     def check_for_processing(self, vs_item_id):
         from models import ImportJob
 
-        jobs = ImportJob.objects.filter(item_id=vs_item_id).filter(processing=True)
+        jobs = ImportJob.objects.filter(item_id=vs_item_id).filter(processing=True).count()
 
-        return len(jobs) > 0
+        return jobs > 0
 
     def import_new_item(self, master_item, content, parent=None):
         from models import ImportJob, PacFormXml
@@ -212,8 +212,8 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
         old_key = self.check_key(content['s3Key'], vs_item_id)
 
         if old_finished_jobs is True and old_key is True:
-            logger.info('Data for item {0} already processed. Aborting.'.format(vs_item_id))
-            inform_sentry('Data for item {0} already processed. Aborting.'.format(vs_item_id), {
+            logger.info('A job for item {0} has already been successfully completed. Aborting.'.format(vs_item_id))
+            inform_sentry('A job for item {0} has already been successfully completed. Aborting.'.format(vs_item_id), {
                 "master_item": master_item,
                 "content": content,
                 "parent": parent
@@ -223,8 +223,8 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
         processing_job = self.check_for_processing(vs_item_id)
 
         if processing_job is True:
-            logger.info('Data for item {0} already being processed. Aborting.'.format(vs_item_id))
-            inform_sentry('Data for item {0} already being processed. Aborting.'.format(vs_item_id), {
+            logger.info('Job for item {0} already in progress. Aborting.'.format(vs_item_id))
+            inform_sentry('Job for item {0} already in progress. Aborting.'.format(vs_item_id), {
                 "master_item": master_item,
                 "content": content,
                 "parent": parent

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -230,7 +230,7 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
             logger.info('Data for item {0} already processed. Aborting.'.format(vs_item_id))
             inform_sentry('Data for item {0} already processed. Aborting.'.format(vs_item_id), {
                 "master_item": master_item,
-                "content": content.__dict__,
+                "content": content,
                 "parent": parent
             })
             return
@@ -241,7 +241,7 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
             logger.info('Data for item {0} already being processed. Aborting.'.format(vs_item_id))
             inform_sentry('Data for item {0} already being processed. Aborting.'.format(vs_item_id), {
                 "master_item": master_item,
-                "content": content.__dict__,
+                "content": content,
                 "parent": parent
             })
             return

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -179,36 +179,21 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
 
         jobs = ImportJob.objects.filter(item_id=vs_item_id).filter(status='FINISHED')
 
-        number = len(jobs)
-
-        if number > 0:
-            return True
-
-        return False
+        return len(jobs) > 0
 
     def check_key(self, key, vs_item_id):
         from models import ImportJob
 
         jobs = ImportJob.objects.filter(item_id=vs_item_id).filter(s3_path=key)
 
-        number = len(jobs)
-
-        if number > 0:
-            return True
-
-        return False
+        return len(jobs) > 0
 
     def check_for_processing(self, vs_item_id):
         from models import ImportJob
 
         jobs = ImportJob.objects.filter(item_id=vs_item_id).filter(processing=True)
 
-        number = len(jobs)
-
-        if number > 0:
-            return True
-
-        return False
+        return len(jobs) > 0
 
     def import_new_item(self, master_item, content, parent=None):
         from models import ImportJob, PacFormXml

--- a/portal/plugins/gnmatomresponder/master_importer.py
+++ b/portal/plugins/gnmatomresponder/master_importer.py
@@ -207,6 +207,9 @@ class MasterImportResponder(KinesisResponder, S3Mixin, VSMixin):
 
         vs_item_id = master_item.get("itemId")
 
+        if vs_item_id is None:
+            vs_item_id = master_item.name
+
         old_finished_jobs = self.check_for_old_finished_jobs(vs_item_id)
 
         old_key = self.check_key(content['s3Key'], vs_item_id)


### PR DESCRIPTION
Bail out if a job with a status of 'FINISHED' exists for the item and the S3 key is not new.

Also includes a fix for an issue with loading the Vidispine id. of the item and a fix for an issue which happened when using get() which I have replaced with a method that uses filter() instead.

@fredex42 