### PR TITLE
reinstate propagation rules

### DIFF
--- a/portal/plugins/gnmpropagation/businesslogic/tickbox_propagation.xml
+++ b/portal/plugins/gnmpropagation/businesslogic/tickbox_propagation.xml
@@ -10,8 +10,7 @@
            logger = logging.getLogger("portal.plugins.gnmpropagation.businesslogic")
            logger.info("Starting propagation from {0}".format(collectionId))
 
-           #result = tasks.propagate.apply_async((collectionId, 'gnm_storage_rule_sensitive', gnm_storage_rule_sensitive, ), queue='propagator')
-           result = "NOT"
+           result = tasks.propagate.apply_async((collectionId, 'gnm_storage_rule_sensitive', gnm_storage_rule_sensitive, ), queue='propagator')
            logger.info("Propagation task {0} scheduled for gnm_storage_rule_sensitive={1} on {2}".format(result, gnm_storage_rule_sensitive, collectionId))
 
         ]]>
@@ -26,8 +25,7 @@
            logger = logging.getLogger("portal.plugins.gnmpropagation.businesslogic")
            logger.info("Starting propagation from {0}".format(collectionId))
 
-           #result = tasks.propagate.apply_async((collectionId, 'gnm_storage_rule_deletable', gnm_storage_rule_deletable, ), queue='propagator')
-           result = "NOT"
+           result = tasks.propagate.apply_async((collectionId, 'gnm_storage_rule_deletable', gnm_storage_rule_deletable, ), queue='propagator')
            logger.info("Propagation task {0} scheduled for gnm_storage_rule_deletable={1} on {2}".format(result, gnm_storage_rule_deletable, collectionId))
         ]]>
     </rule>
@@ -40,8 +38,7 @@
            logger = logging.getLogger("portal.plugins.gnmpropagation.businesslogic")
            logger.info("Starting propagation from {0}".format(collectionId))
 
-           #result = tasks.propagate.apply_async((collectionId, 'gnm_storage_rule_deep_archive', gnm_storage_rule_deep_archive, ), queue='propagator')
-           result = "NOT"
+           result = tasks.propagate.apply_async((collectionId, 'gnm_storage_rule_deep_archive', gnm_storage_rule_deep_archive, ), queue='propagator')
            logger.info("Propagation task {0} scheduled for gnm_storage_rule_deep_archive={1} on {2}".format(result, gnm_storage_rule_deep_archive, collectionId))
         ]]>
     </rule>


### PR DESCRIPTION
Reverts https://github.com/guardian/portal-plugins-public/pull/64, puts back potentially recursive propagation rules