### PR TITLE
Improve exception handling in atom responder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,10 +64,6 @@ jobs:
     ### gnmatomresponder
     - run: DJANGO_SETTINGS_MODULE=portal.plugins.gnmatomresponder.tests.django_test_settings nosetests -v portal/plugins/gnmatomresponder/tests --xunit-file=${CIRCLE_TEST_REPORTS}/gnmatomresponder.xml
 
-    ### gnmdownloadablelink
-    - run: DJANGO_SETTINGS_MODULE=portal.plugins.gnmdownloadablelink.tests.django_test_settings nosetests -v portal/plugins/gnmdownloadablelink/tests --xunit-file=${CIRCLE_TEST_REPORTS}/gnmdownloadablelink.xml
-    - run: cd portal/plugins/gnmdownloadablelink; npm run test
-
     ### gnmoptin
     - run: DJANGO_SETTINGS_MODULE=portal.plugins.gnmoptin.tests.django_test_settings nosetests -v portal/plugins/gnmoptin/tests --xunit-file=${CIRCLE_TEST_REPORTS}/gnmoptin.xml
 

--- a/portal/plugins/gnmatomresponder/views.py
+++ b/portal/plugins/gnmatomresponder/views.py
@@ -23,6 +23,7 @@ class JobNotifyView(APIView):
         from job_notification import JobNotification
         from lxml.etree import XMLSyntaxError, LxmlError
         from notification import process_notification
+        from models import ImportJob
         import traceback
 
         logger.info("Received import notification")
@@ -35,9 +36,12 @@ class JobNotifyView(APIView):
             logger.error("Unable to process Vidispine XML document, but syntax as ok")
             return Response({'status': 'Unable to process'}, status=500) #returning 500=> VS will try again (more likely problem is our side)
 
-        process_notification(notification)
-
-        return Response({'status': 'ok'})
+        try:
+            process_notification(notification)
+            return Response({'status': 'ok'})
+        except ImportJob.DoesNotExist:
+            logger.error("JobNotifyView: No import job found for {0}".format(notification))
+            return Response({'status': 'notfound'}, status=404)
 
 
 class ImportJobListView(ListView):

--- a/portal/plugins/gnmatomresponder/views.py
+++ b/portal/plugins/gnmatomresponder/views.py
@@ -41,7 +41,7 @@ class JobNotifyView(APIView):
             return Response({'status': 'ok'})
         except ImportJob.DoesNotExist:
             logger.error("JobNotifyView: No import job found for {0}".format(notification))
-            return Response({'status': 'notfound'}, status=404)
+            return Response({'status': 'notfound'}, status=200)
 
 
 class ImportJobListView(ListView):


### PR DESCRIPTION
If no import job exists for an incoming file, then catch the exception and report, don't break